### PR TITLE
Rename project from kafka-python to kafka-python-ng

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -413,7 +413,7 @@ Some of the major changes include:
 * SASL authentication is working (we think)
 * Removed several circular references to improve gc on close()
 
-Thanks to all contributors -- the state of the kafka-python community is strong!
+Thanks to all contributors -- the state of the kafka-python-ng community is strong!
 
 Detailed changelog are listed below:
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ cov-local: build-integration
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 # Check the readme for syntax errors, which can lead to invalid formatting on
-# PyPi homepage (https://pypi.python.org/pypi/kafka-python)
+# PyPi homepage (https://pypi.python.org/pypi/kafka-python-ng)
 check-readme:
 	python setup.py check -rms
 

--- a/README.rst
+++ b/README.rst
@@ -2,27 +2,27 @@ Kafka Python client
 ------------------------
 
 .. image:: https://img.shields.io/badge/kafka-2.6%2C%202.5%2C%202.4%2C%202.3%2C%202.2%2C%202.1%2C%202.0%2C%201.1%2C%201.0%2C%200.11%2C%200.10%2C%200.9%2C%200.8-brightgreen.svg
-    :target: https://kafka-python.readthedocs.io/en/master/compatibility.html
-.. image:: https://img.shields.io/pypi/pyversions/kafka-python.svg
-    :target: https://pypi.python.org/pypi/kafka-python
-.. image:: https://coveralls.io/repos/dpkp/kafka-python/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/dpkp/kafka-python?branch=master
+    :target: https://kafka-python-ng.readthedocs.io/en/master/compatibility.html
+.. image:: https://img.shields.io/pypi/pyversions/kafka-python-ng.svg
+    :target: https://pypi.python.org/pypi/kafka-python-ng
+.. image:: https://coveralls.io/repos/wbarnha/kafka-python-ng-ng/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/wbarnha/kafka-python-ng-ng?branch=master
 .. image:: https://img.shields.io/badge/license-Apache%202-blue.svg
-    :target: https://github.com/dpkp/kafka-python/blob/master/LICENSE
-.. image:: https://img.shields.io/pypi/dw/kafka-python.svg
+    :target: https://github.com/wbarnha/kafka-python-ng-ng/blob/master/LICENSE
+.. image:: https://img.shields.io/pypi/dw/kafka-python-ng.svg
     :target: https://pypistats.org/packages/kafka-python
 .. image:: https://img.shields.io/pypi/v/kafka-python.svg
     :target: https://pypi.org/project/kafka-python
 .. image:: https://img.shields.io/pypi/implementation/kafka-python
-    :target: https://github.com/dpkp/kafka-python/blob/master/setup.py
+    :target: https://github.com/wbarnha/kafka-python-ng/blob/master/setup.py
 
 
 
 Python client for the Apache Kafka distributed stream processing system.
-kafka-python is designed to function much like the official java client, with a
+kafka-python-ng is designed to function much like the official java client, with a
 sprinkling of pythonic interfaces (e.g., consumer iterators).
 
-kafka-python is best used with newer brokers (0.9+), but is backwards-compatible with
+kafka-python-ng is best used with newer brokers (0.9+), but is backwards-compatible with
 older versions (to 0.8.0). Some features will only be enabled on newer brokers.
 For example, fully coordinated consumer groups -- i.e., dynamic partition
 assignment to multiple consumers in the same group -- requires use of 0.9+ kafka
@@ -32,13 +32,13 @@ check code (perhaps using zookeeper or consul). For older brokers, you can
 achieve something similar by manually assigning different partitions to each
 consumer instance with config management tools like chef, ansible, etc. This
 approach will work fine, though it does not support rebalancing on failures.
-See <https://kafka-python.readthedocs.io/en/master/compatibility.html>
+See <https://kafka-python-ng.readthedocs.io/en/master/compatibility.html>
 for more details.
 
 Please note that the master branch may contain unreleased features. For release
 documentation, please see readthedocs and/or python's inline help.
 
->>> pip install kafka-python
+>>> pip install kafka-python-ng
 
 
 KafkaConsumer
@@ -48,7 +48,7 @@ KafkaConsumer is a high-level message consumer, intended to operate as similarly
 as possible to the official java client. Full support for coordinated
 consumer groups requires use of kafka brokers that support the Group APIs: kafka v0.9+.
 
-See <https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html>
+See <https://kafka-python-ng.readthedocs.io/en/master/apidoc/KafkaConsumer.html>
 for API and configuration details.
 
 The consumer iterator returns ConsumerRecords, which are simple namedtuples
@@ -91,7 +91,7 @@ KafkaProducer
 
 KafkaProducer is a high-level, asynchronous message producer. The class is
 intended to operate as similarly as possible to the official java client.
-See <https://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html>
+See <https://kafka-python-ng.readthedocs.io/en/master/apidoc/KafkaProducer.html>
 for more details.
 
 >>> from kafka import KafkaProducer
@@ -146,7 +146,7 @@ multiprocessing is recommended.
 Compression
 ***********
 
-kafka-python supports the following compression formats:
+kafka-python-ng supports the following compression formats:
 
 - gzip
 - LZ4
@@ -154,23 +154,23 @@ kafka-python supports the following compression formats:
 - Zstandard (zstd)
 
 gzip is supported natively, the others require installing additional libraries.
-See <https://kafka-python.readthedocs.io/en/master/install.html> for more information.
+See <https://kafka-python-ng.readthedocs.io/en/master/install.html> for more information.
 
 
 Optimized CRC32 Validation
 **************************
 
-Kafka uses CRC32 checksums to validate messages. kafka-python includes a pure
+Kafka uses CRC32 checksums to validate messages. kafka-python-ng includes a pure
 python implementation for compatibility. To improve performance for high-throughput
-applications, kafka-python will use `crc32c` for optimized native code if installed.
-See <https://kafka-python.readthedocs.io/en/master/install.html> for installation instructions.
+applications, kafka-python-ng will use `crc32c` for optimized native code if installed.
+See <https://kafka-python-ng.readthedocs.io/en/master/install.html> for installation instructions.
 See https://pypi.org/project/crc32c/ for details on the underlying crc32c lib.
 
 
 Protocol
 ********
 
-A secondary goal of kafka-python is to provide an easy-to-use protocol layer
+A secondary goal of kafka-python-ng is to provide an easy-to-use protocol layer
 for interacting with kafka brokers via the python repl. This is useful for
 testing, probing, and general experimentation. The protocol support is
 leveraged to enable a KafkaClient.check_version() method that

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -85,17 +85,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/kafka-python.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/kafka-python-ng.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/kafka-python.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/kafka-python-ng.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/kafka-python"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/kafka-python"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/kafka-python-ng"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/kafka-python-ng"
 	@echo "# devhelp"
 
 epub:

--- a/docs/apidoc/modules.rst
+++ b/docs/apidoc/modules.rst
@@ -1,4 +1,4 @@
-kafka-python API
+kafka-python-ng API
 ****************
 
 .. toctree::

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -484,7 +484,7 @@ Some of the major changes include:
 * SASL authentication is working (we think)
 * Removed several circular references to improve gc on close()
 
-Thanks to all contributors -- the state of the kafka-python community is strong!
+Thanks to all contributors -- the state of the kafka-python-ng community is strong!
 
 Detailed changelog are listed below:
 

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -2,20 +2,20 @@ Compatibility
 -------------
 
 .. image:: https://img.shields.io/badge/kafka-2.6%2C%202.5%2C%202.4%2C%202.3%2C%202.2%2C%202.1%2C%202.0%2C%201.1%2C%201.0%2C%200.11%2C%200.10%2C%200.9%2C%200.8-brightgreen.svg
-    :target: https://kafka-python.readthedocs.io/compatibility.html
-.. image:: https://img.shields.io/pypi/pyversions/kafka-python.svg
-    :target: https://pypi.python.org/pypi/kafka-python
+    :target: https://kafka-python-ng.readthedocs.io/compatibility.html
+.. image:: https://img.shields.io/pypi/pyversions/kafka-python-ng.svg
+    :target: https://pypi.python.org/pypi/kafka-python-ng
 
-kafka-python is compatible with (and tested against) broker versions 2.6
-through 0.8.0 . kafka-python is not compatible with the 0.8.2-beta release.
+kafka-python-ng is compatible with (and tested against) broker versions 2.6
+through 0.8.0 . kafka-python-ng is not compatible with the 0.8.2-beta release.
 
-Because the kafka server protocol is backwards compatible, kafka-python is
+Because the kafka server protocol is backwards compatible, kafka-python-ng is
 expected to work with newer broker releases as well.
 
-Although kafka-python is tested and expected to work on recent broker versions,
+Although kafka-python-ng is tested and expected to work on recent broker versions,
 not all features are supported. Specifically, authentication codecs, and
 transactional producer/consumer support are not fully implemented. PRs welcome!
 
-kafka-python is tested on python 2.7, 3.4, 3.7, 3.8 and pypy2.7.
+kafka-python-ng is tested on python 2.7, 3.4, 3.7, 3.8 and pypy2.7.
 
-Builds and tests via Travis-CI.  See https://travis-ci.org/dpkp/kafka-python
+Builds and tests via Travis-CI.  See https://travis-ci.org/wbarnha/kafka-python-ng

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# kafka-python documentation build configuration file, created by
+# kafka-python-ng documentation build configuration file, created by
 # sphinx-quickstart on Sun Jan  4 12:21:50 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -47,7 +47,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'kafka-python'
+project = u'kafka-python-ng'
 copyright = u'2016 -- Dana Powers, David Arthur, and Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -201,7 +201,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'kafka-python.tex', u'kafka-python Documentation',
+  ('index', 'kafka-python-ng.tex', u'kafka-python-ng Documentation',
    u'Dana Powers', 'manual'),
 ]
 
@@ -231,7 +231,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'kafka-python', u'kafka-python Documentation',
+    ('index', 'kafka-python-ng', u'kafka-python-ng Documentation',
      [u'Dana Powers'], 1)
 ]
 
@@ -245,7 +245,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'kafka-python', u'kafka-python Documentation',
+  ('index', 'kafka-python-ng', u'kafka-python-ng Documentation',
    u'Dana Powers', 'kafka-python', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,16 @@
-kafka-python
+kafka-python-ng
 ############
 
 .. image:: https://img.shields.io/badge/kafka-2.6%2C%202.5%2C%202.4%2C%202.3%2C%202.2%2C%202.1%2C%202.0%2C%201.1%2C%201.0%2C%200.11%2C%200.10%2C%200.9%2C%200.8-brightgreen.svg
     :target: https://kafka-python.readthedocs.io/en/master/compatibility.html
 .. image:: https://img.shields.io/pypi/pyversions/kafka-python.svg
-    :target: https://pypi.python.org/pypi/kafka-python
-.. image:: https://coveralls.io/repos/dpkp/kafka-python/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/dpkp/kafka-python?branch=master
-.. image:: https://travis-ci.org/dpkp/kafka-python.svg?branch=master
-    :target: https://travis-ci.org/dpkp/kafka-python
+    :target: https://pypi.python.org/pypi/kafka-python-ng
+.. image:: https://coveralls.io/repos/wbarnha/kafka-python-ng/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/wbarnha/kafka-python-ng?branch=master
+.. image:: https://travis-ci.org/wbarnha/kafka-python-ng.svg?branch=master
+    :target: https://travis-ci.org/wbarnha/kafka-python-ng
 .. image:: https://img.shields.io/badge/license-Apache%202-blue.svg
-    :target: https://github.com/dpkp/kafka-python/blob/master/LICENSE
+    :target: https://github.com/wbarnha/kafka-python-ng/blob/master/LICENSE
 
 Python client for the Apache Kafka distributed stream processing system.
 kafka-python is designed to function much like the official java client, with a
@@ -31,7 +31,7 @@ failures.  See `Compatibility <compatibility.html>`_ for more details.
 Please note that the master branch may contain unreleased features. For release
 documentation, please see readthedocs and/or python's inline help.
 
->>> pip install kafka-python
+>>> pip install kafka-python-ng
 
 
 KafkaConsumer

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,9 +9,9 @@ Pip:
 
 .. code:: bash
 
-    pip install kafka-python
+    pip install kafka-python-ng
 
-Releases are also listed at https://github.com/dpkp/kafka-python/releases
+Releases are also listed at https://github.com/wbarnha/kafka-python-ng/releases
 
 
 Bleeding-Edge
@@ -19,21 +19,21 @@ Bleeding-Edge
 
 .. code:: bash
 
-    git clone https://github.com/dpkp/kafka-python
-    pip install ./kafka-python
+    git clone https://github.com/wbarnha/kafka-python-ng
+    pip install ./kafka-python-ng
 
 
 Optional crc32c install
 ***********************
-Highly recommended if you are using Kafka 11+ brokers. For those `kafka-python`
+Highly recommended if you are using Kafka 11+ brokers. For those `kafka-python-ng`
 uses a new message protocol version, that requires calculation of `crc32c`,
-which differs from the `zlib.crc32` hash implementation. By default `kafka-python`
+which differs from the `zlib.crc32` hash implementation. By default `kafka-python-ng`
 calculates it in pure python, which is quite slow. To speed it up we optionally
 support https://pypi.python.org/pypi/crc32c package if it's installed.
 
 .. code:: bash
 
-    pip install 'kafka-python[crc32c]'
+    pip install 'kafka-python-ng[crc32c]'
 
 
 Optional ZSTD install
@@ -41,7 +41,7 @@ Optional ZSTD install
 
 To enable ZSTD compression/decompression, install python-zstandard:
 
->>> pip install 'kafka-python[zstd]'
+>>> pip install 'kafka-python-ng[zstd]'
 
 
 Optional LZ4 install
@@ -49,7 +49,7 @@ Optional LZ4 install
 
 To enable LZ4 compression/decompression, install python-lz4:
 
->>> pip install 'kafka-python[lz4]'
+>>> pip install 'kafka-python-ng[lz4]'
 
 
 Optional Snappy install
@@ -90,4 +90,4 @@ Install the `python-snappy` module
 
 .. code:: bash
 
-    pip install 'kafka-python[snappy]'
+    pip install 'kafka-python-ng[snappy]'

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -2,9 +2,9 @@ License
 -------
 
 .. image:: https://img.shields.io/badge/license-Apache%202-blue.svg
-    :target: https://github.com/dpkp/kafka-python/blob/master/LICENSE
+    :target: https://github.com/wbarnha/kafka-python-ng/blob/master/LICENSE
 
-Apache License, v2.0. See `LICENSE <https://github.com/dpkp/kafka-python/blob/master/LICENSE>`_.
+Apache License, v2.0. See `LICENSE <https://github.com/wbarnha/kafka-python-ng/blob/master/LICENSE>`_.
 
 Copyright 2016, Dana Powers, David Arthur, and Contributors
-(See `AUTHORS <https://github.com/dpkp/kafka-python/blob/master/AUTHORS.md>`_).
+(See `AUTHORS <https://github.com/wbarnha/kafka-python-ng/blob/master/AUTHORS.md>`_).

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,7 +1,7 @@
 Support
 -------
 
-For support, see github issues at https://github.com/dpkp/kafka-python
+For support, see github issues at https://github.com/wbarnha/kafka-python-ng
 
 Limited IRC chat at #kafka-python on freenode (general chat is #apache-kafka).
 

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -1,17 +1,17 @@
 Tests
 =====
 
-.. image:: https://coveralls.io/repos/dpkp/kafka-python/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/dpkp/kafka-python?branch=master
-.. image:: https://travis-ci.org/dpkp/kafka-python.svg?branch=master
-    :target: https://travis-ci.org/dpkp/kafka-python
+.. image:: https://coveralls.io/repos/wbarnha/kafka-python-ng/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/wbarnha/kafka-python-ng?branch=master
+.. image:: https://travis-ci.org/wbarnha/kafka-python-ng.svg?branch=master
+    :target: https://travis-ci.org/wbarnha/kafka-python-ng
 
 Test environments are managed via tox. The test suite is run via pytest.
 
 Linting is run via pylint, but is generally skipped on pypy due to pylint
 compatibility / performance issues.
 
-For test coverage details, see https://coveralls.io/github/dpkp/kafka-python
+For test coverage details, see https://coveralls.io/github/wbarnha/kafka-python-ng
 
 The test suite includes unit tests that mock network interfaces, as well as
 integration tests that setup and teardown kafka broker (and zookeeper)

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,9 @@
-__version__ = '2.0.3-dev'
+import sys
+
+if sys.version_info < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
+
+
+__version__ = version("kafka-python-ng")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup, Command, find_packages
 
 # Pull version from source without importing
 # since we can't import something we haven't built yet :)
-exec(open('kafka/version.py').read())
 
 
 class Tox(Command):
@@ -32,9 +31,9 @@ with open(os.path.join(here, 'README.rst')) as f:
     README = f.read()
 
 setup(
-    name="kafka-python",
-    version=__version__,
-
+    name="kafka-python-ng",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     tests_require=test_require,
     extras_require={
         "crc32c": ["crc32c"],
@@ -46,7 +45,9 @@ setup(
     packages=find_packages(exclude=['test']),
     author="Dana Powers",
     author_email="dana.powers@gmail.com",
-    url="https://github.com/dpkp/kafka-python",
+    maintainer="William Barnhart",
+    maintainer_email="williambbarnhart@gmail.com",
+    url="https://github.com/wbarnha/kafka-python-ng",
     license="Apache License 2.0",
     description="Pure Python client for Apache Kafka",
     long_description=README,


### PR DESCRIPTION
Rename project so we can start publishing to https://pypi.org/project/kafka-python-ng/