### PR TITLE
Update license_file to license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal=1
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
The former has been deprecated since setuptools 56

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2415)
<!-- Reviewable:end -->