### PR TITLE
Flush before close

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -469,6 +469,8 @@ class KafkaProducer(object):
             timeout (float, optional): timeout in seconds to wait for completion.
         """
 
+        # If there are any pending messages, send them now
+        self.flush(timeout)
         # drop our atexit handler now to avoid leaks
         self._unregister_cleanup()
 


### PR DESCRIPTION
If there are any messages pending, flush them before doing anything else. This makes it more likely that callbacks have a chance to run before the producer is closed, which can help in corner cases (like when callbacks want to send another message)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2213)
<!-- Reviewable:end -->