### PR TITLE
feat: logged cancelled exception as info messages

### DIFF
--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -373,8 +373,8 @@ def test_fetched_records(fetcher, topic, mocker):
         1,
     ),
 ])
-def test__handle_fetch_response(fetcher, fetch_request, fetch_response, num_partitions):
-    fetcher._handle_fetch_response(fetch_request, time.time(), fetch_response)
+def test__handle_fetch_success(fetcher, fetch_request, fetch_response, num_partitions):
+    fetcher._handle_fetch_success(fetch_request, time.time(), fetch_response)
     assert len(fetcher._completed_fetches) == num_partitions
 
 


### PR DESCRIPTION
we manual interrupt our connection so all inflight request which was canceled by this reason shouldn't log it as an error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2172)
<!-- Reviewable:end -->