### PR TITLE
Always use config to set default value of timeout in check version

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -869,7 +869,7 @@ class KafkaClient(object):
         """
         return self._api_versions
 
-    def check_version(self, node_id=None, timeout=2, strict=False):
+    def check_version(self, node_id=None, timeout=None, strict=False):
         """Attempt to guess the version of a Kafka broker.
 
         Note: It is possible that this method blocks longer than the
@@ -885,6 +885,9 @@ class KafkaClient(object):
             UnrecognizedBrokerVersion: please file bug if seen!
             AssertionError (if strict=True): please file bug if seen!
         """
+        if timeout is None:
+            timeout = self.config['api_version_auto_timeout_ms'] / 1000
+
         self._lock.acquire()
         end = time.time() + timeout
         while time.time() < end:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2108)
<!-- Reviewable:end -->