### PR TITLE
Propagate future.exception in producer/kafka.py _wait_on_metadata

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -854,7 +854,7 @@ class Fetcher(six.Iterator):
 
             elif error_type is Errors.TopicAuthorizationFailedError:
                 log.warning("Not authorized to read from topic %s.", tp.topic)
-                raise Errors.TopicAuthorizationFailedError(set(tp.topic))
+                raise Errors.TopicAuthorizationFailedError(tp.topic)
             elif error_type is Errors.UnknownError:
                 log.warning("Unknown error fetching data for topic-partition %s", tp)
             else:

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -686,6 +686,8 @@ class KafkaProducer(object):
             self._sender.wakeup()
             metadata_event.wait(max_wait - elapsed)
             elapsed = time.time() - begin
+            if future.exception:
+                raise future.exception
             if not metadata_event.is_set():
                 raise Errors.KafkaTimeoutError(
                     "Failed to update metadata after %.1f secs." % (max_wait,))


### PR DESCRIPTION
Propagate any exceptions that happened during the future; otherwise _wait_on_metadata will time out even though the error is being continuously reflected in the metadata status fetched from the broker.  Issue #2078

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2082)
<!-- Reviewable:end -->