### PR TITLE
Test Kafka 0.8.2.2 using Python 3.10 in the meantime

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -132,7 +132,9 @@ jobs:
         include:
           - kafka-version: '0.8.2.2'
             experimental: true
+            python-version: "3.12"
           - kafka-version: '0.8.2.2'
+            experimental: false
             python-version: "3.11"
     env:
       PYTHON_LATEST: ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -127,13 +127,14 @@ jobs:
           - "2.4.0"
           - "2.5.0"
           - "2.6.0"
+        python-version: ['${{ env.PYTHON_LATEST }}']
         experimental: [false]
         include:
           - kafka-version: '0.8.2.2'
             experimental: true
           - kafka-version: '0.8.2.2'
             experimental: false
-            PYTHON_LATEST: "3.11"
+            python-version: "3.11"
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout the source code
@@ -148,7 +149,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_LATEST }}
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
             requirements-dev.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -131,6 +131,9 @@ jobs:
         include:
           - kafka-version: '0.8.2.2'
             experimental: true
+          - kafka-version: '0.8.2.2'
+            experimental: false
+            PYTHON_LATEST: "3.11"
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout the source code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -135,7 +135,7 @@ jobs:
             python-version: "3.12"
           - kafka-version: '0.8.2.2'
             experimental: false
-            python-version: "3.11"
+            python-version: "3.10"
     env:
       PYTHON_LATEST: ${{ matrix.python-version }}
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -110,7 +110,7 @@ jobs:
           KAFKA_VERSION: ${{ env.KAFKA_LATEST }}
 
   test-kafka:
-    name: Tests for Kafka ${{ matrix.kafka-version }}
+    name: Tests for Kafka ${{ matrix.kafka-version }} (Python ${{ matrix.python-version }})
     needs:
       - build-sdist
     runs-on: ubuntu-latest
@@ -133,7 +133,6 @@ jobs:
           - kafka-version: '0.8.2.2'
             experimental: true
           - kafka-version: '0.8.2.2'
-            experimental: false
             python-version: "3.11"
     env:
       PYTHON_LATEST: ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -127,7 +127,7 @@ jobs:
           - "2.4.0"
           - "2.5.0"
           - "2.6.0"
-        python-version: ['${{ env.PYTHON_LATEST }}']
+        python-version: ['3.12']
         experimental: [false]
         include:
           - kafka-version: '0.8.2.2'
@@ -135,6 +135,8 @@ jobs:
           - kafka-version: '0.8.2.2'
             experimental: false
             python-version: "3.11"
+    env:
+      PYTHON_LATEST: ${{ matrix.python-version }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout the source code


### PR DESCRIPTION
Since 3.12 can't support Kafka v0.8.2.2 at the moment, but we know older versions of Python can, let's try to use an earlier version just to make sure we don't break anything for users until we document it.