### PR TITLE
Stop testing Python 3.13 in python-package.yml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -68,9 +68,6 @@ jobs:
           - "3.12"
           - "pypy3.9"
         experimental: [ false ]
-        include:
-          - python-version: "~3.13.0-0"
-            experimental: true
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4


### PR DESCRIPTION
Too many MRs to review... so little time.