### PR TITLE
Update __init__.py of SASL to catch ImportErrors in case botocore is not installed

### DIFF
--- a/kafka/sasl/__init__.py
+++ b/kafka/sasl/__init__.py
@@ -1,8 +1,6 @@
 import logging
 
-from kafka.sasl import gssapi, oauthbearer, plain, scram, msk
-
-log = logging.getLogger(__name__)
+from kafka.sasl import gssapi, oauthbearer, plain, scram
 
 MECHANISMS = {
     'GSSAPI': gssapi,
@@ -10,8 +8,15 @@ MECHANISMS = {
     'PLAIN': plain,
     'SCRAM-SHA-256': scram,
     'SCRAM-SHA-512': scram,
-    'AWS_MSK_IAM': msk,
 }
+
+try:
+    from kafka.sasl import msk
+    MECHANISMS['AWS_MSK_IAM'] = msk
+except ImportError:
+    pass
+
+log = logging.getLogger(__name__)
 
 
 def register_mechanism(key, module):


### PR DESCRIPTION
Bit of a lazy fix, I was hoping to do something more graceful, but I'm a bit sidetracked at the moment.

Closes https://github.com/wbarnha/kafka-python-ng/issues/174.