### PR TITLE
Increase consumer group test timeout

### DIFF
--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -74,7 +74,7 @@ def test_group(kafka_broker, topic):
         threads[i] = t
 
     try:
-        timeout = time.time() + 35
+        timeout = time.time() + 350
         while True:
             for c in range(num_consumers):
 


### PR DESCRIPTION
Test `test/test_consumer_group.py::test_group` failed. Increase timeout to find out if it is just slow or real failure.