### PR TITLE
Avoid busy retry

### DIFF
--- a/test/test_admin_integration.py
+++ b/test/test_admin_integration.py
@@ -220,6 +220,7 @@ def test_describe_consumer_group_exists(kafka_admin_client, kafka_consumer_facto
                 else:
                     sleep(1)
             assert time() < timeout, "timeout waiting for assignments"
+            sleep(0.25)
 
         info('Group stabilized; verifying assignment')
         output = kafka_admin_client.describe_consumer_groups(group_id_list)

--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -111,6 +111,7 @@ def test_group(kafka_broker, topic):
                     logging.info('Rejoining: %s, generations: %s', rejoining, generations)
                     time.sleep(1)
             assert time.time() < timeout, "timeout waiting for assignments"
+            time.sleep(0.25)
 
         logging.info('Group stabilized; verifying assignment')
         group_assignment = set()


### PR DESCRIPTION
Test `test/test_consumer_group.py::test_group` and `test/test_admin_integration.py::test_describe_consumer_group_exists` busy-retry and this might have caused Java not having enough CPU time on GitHub runner, and result in test failure.