### PR TITLE
Fix SCRAM username character escape

### DIFF
--- a/kafka/scram.py
+++ b/kafka/scram.py
@@ -30,7 +30,7 @@ class ScramClient:
         self.server_signature = None
 
     def first_message(self):
-        client_first_bare = f'n={self.user},r={self.nonce}'
+        client_first_bare = f'n={self.user.replace("=","=3D").replace(",","=2C")},r={self.nonce}'
         self.auth_message += client_first_bare
         return 'n,,' + client_first_bare
 


### PR DESCRIPTION
According to [rfc5802](https://datatracker.ietf.org/doc/html/rfc5802), username should escape special characters before sending to the server.

> The characters ',' or '=' in usernames are sent as '=2C' and
>  '=3D' respectively.  If the server receives a username that
>  contains '=' not followed by either '2C' or '3D', then the
>  server MUST fail the authentication.