### PR TITLE
Don't use root logger in kafka.sasl.scram

### DIFF
--- a/kafka/sasl/scram.py
+++ b/kafka/sasl/scram.py
@@ -5,7 +5,7 @@ import kafka.errors as Errors
 from kafka.protocol.types import Int32
 from kafka.scram import ScramClient
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def validate_config(conn):


### PR DESCRIPTION
All other modules in this repository correctly use getLogger(__name__) and so should sasl.scram ;-)