### PR TITLE
Fix reconsuming first message of a topic when manually committing

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -668,7 +668,7 @@ class Fetcher:
             node_id = self._client.cluster.leader_for_partition(partition)
 
             # advance position for any deleted compacted messages if required
-            if self._subscriptions.assignment[partition].last_offset_from_message_batch:
+            if self._subscriptions.assignment[partition].last_offset_from_message_batch is not None:
                 next_offset_from_batch_header = self._subscriptions.assignment[partition].last_offset_from_message_batch + 1
                 if next_offset_from_batch_header > self._subscriptions.assignment[partition].position:
                     log.debug(


### PR DESCRIPTION
I encountered an issue in which the very first message of a topic is reconsumed until a second message occurs when manually committing. 
I created a reproduction here: https://github.com/WietseJT/Kafka-python-ng-repeating-demo

This bug occurs because when last_offset_from_message_batch is 0 it doesn't pass the following if-check:
`if self._subscriptions.assignment[partition].last_offset_from_message_batch` 
